### PR TITLE
remove compiler pins as these are no longer needed

### DIFF
--- a/libclock_gettime_wrapper/meta.yaml
+++ b/libclock_gettime_wrapper/meta.yaml
@@ -6,17 +6,12 @@ source:
   - path: ./
 
 build:
-  number: 4
+  number: 5
   string: {{ PKG_BUILDNUM }}
   
 requirements:
   build:
     - {{ compiler('c') }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-  host:
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
 
 about:
   home: open-ce

--- a/libmemcpy_wrapper/meta.yaml
+++ b/libmemcpy_wrapper/meta.yaml
@@ -6,17 +6,12 @@ source:
   - path: ./
 
 build:
-  number: 4
+  number: 5
   string: {{ PKG_BUILDNUM }}
   
 requirements:
   build:
     - {{ compiler('c') }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-  host:
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
 
 about:
   home: open-ce


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Requires - https://github.com/open-ce/open-ce/pull/501
Remove compiler pins as these are no longer required now, since we are moving to GCC 7.5 on x86.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
